### PR TITLE
Add setup step for .cazan directory in workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Setup .cazan directory
+        run: |
+          mkdir .cazan/build
+          echo "[]" > .cazan/build/assets.json
+          echo "[]" > .cazan/build/assets.json.import-test
       - name: Test
         run: cargo test --all-features
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Setup .cazan directorygt
+        run: |
+          mkdir .cazan/build
+          echo "[]" > .cazan/build/assets.json
+          echo "[]" > .cazan/build/assets.json.import-test
       - name: Test
         run: cargo test --all-features
 


### PR DESCRIPTION
This commit introduces setup steps for .cazan directory in both release and pull-request workflows. These steps create the .cazan/build directory and generate two json files inside it. This setup step was necessary to ensure the workflows have the needed directories and files for testing all features of the application.