### PR TITLE
Modify mkdir in workflow files to prevent errors

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup .cazan directory
         run: |
-          mkdir .cazan/build
+          mkdir -p .cazan/build
           echo "[]" > .cazan/build/assets.json
           echo "[]" > .cazan/build/assets.json.import-test
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup .cazan directorygt
         run: |
-          mkdir .cazan/build
+          mkdir -p .cazan/build
           echo "[]" > .cazan/build/assets.json
           echo "[]" > .cazan/build/assets.json.import-test
       - name: Test


### PR DESCRIPTION
Changed the `mkdir` command to `mkdir -p` in both the release.yml and pull-request.yml files under the .github/workflows directory. This modification ensures the intermediate directories are created if they do not already exist, preventing any potential workflow failures.