### PR TITLE
Add packaging step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Package
+        run: cargo package --all-features
       - name: Publish
-        run: cargo publish --all-features --dry-run
+        run: cargo publish --all-features
         env:
           CRATES_IO_TOKEN: ${{ secrets.CAZAN_CRATES_IO_TOKEN }}


### PR DESCRIPTION
Add packaging step and Remove the '--dry-run' flag from the publish step to enable actual publishing.